### PR TITLE
Support from hostsVN - advertising block of Vietnam

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,7 @@
   <li class="bdTick"><a href="https://pgl.yoyo.org/adservers/">Peter Lowe's Adservers</a><a href="https://pgl.yoyo.org/adservers/serverlist.php?hostformat=hosts;showintro=0">https://pgl.yoyo.org/adservers/serverlist.php?hostformat=hosts;showintro=0</a></li>
   <li class="bdTick"><a href="https://github.com/StevenBlack/hosts">Steven Black's Unchecky Ads:</a><a href="https://raw.githubusercontent.com/StevenBlack/hosts/master/data/UncheckyAds/hosts">https://raw.githubusercontent.com/StevenBlack/hosts/master/data/UncheckyAds/hosts</a></li>
   <li class="bdTick"><a href="http://www.squidblacklist.org/downloads.html">Squidblacklist Ads &amp; Tracking:</a><a href="https://www.squidblacklist.org/downloads/dg-ads.acl">https://www.squidblacklist.org/downloads/dg-ads.acl</a></li>
+  <li class="bdTick"><a href="https://github.com/bigdargon/hostsVN">hostsVN:</a><a href="https://raw.githubusercontent.com/bigdargon/hostsVN/master/hosts">https://raw.githubusercontent.com/bigdargon/hostsVN/master/hosts</a></li>
 </ul>
 
 <h2>Tracking &amp; Telemetry Lists</h2>
@@ -173,7 +174,7 @@
   <li>alluremedia.com.au <span class="bdDesc">(Used by Gizmodo sites)</span></li>
   <li>tomshardware.com</li>
 </ul>
-<h4>Blocked by Reddestdream</h4>
+<h4>Blocked by Reddestdream & hostsVN</h4>
 <ul>
   <li>ocsp.apple.com <span class="bdDesc">(Used by Apple devices for certificate validation)</span></li>
 </ul>


### PR DESCRIPTION
Hello!

I am from Vietnam, I have a project `hostsVN` for the purpose of blocking ads and tracking from advertisers from Vietnam. Wishing to support ad blocking projects that support blocking domains in Vietnam, so I created this issue hoping you will merge with hostsVN. The project has been maintained for more than 1 year and continuously updates new domain names.

Github: https://github.com/bigdargon/hostsVN/

Some sources use hostsVN:
- https://abpvn.com/android/
- https://github.com/AdguardTeam/AdGuardSDNSFilter/blob/2437fd7f0b9586ef53a417dd63a59deac43452b0/Filters/filter.template#L92
- in `nextdns` lists

I have a hosts file that supports all advertisers and followers that Vietnamese people regularly access. Link https://raw.githubusercontent.com/bigdargon/hostsVN/master/hosts

And the hosts file I categorized only includes domain name blocking ads and tracking in Vietnam. I hope you just need to merge this file. Link https://raw.githubusercontent.com/bigdargon/hostsVN/master/option/hosts-VN

Thanks you!