### PR TITLE
Update links to BarbBlock

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
   <li><a href="https://winhelp2002.mvps.org/">Winhelp2002 MVPS:</a><a href="https://winhelp2002.mvps.org/hosts.txt">https://winhelp2002.mvps.org/hosts.txt</a></li>
   <li><a href="https://github.com/neofelhz/neohosts">neoFelhz's neoHosts:</a><a href="https://hosts.nfz.moe/basic/hosts">https://hosts.nfz.moe/basic/hosts</a></li>
   <li><a href="https://github.com/RooneyMcNibNug/pihole-stuff/">RooneyMcNibNug's SNAFU list:</a><a href="https://raw.githubusercontent.com/RooneyMcNibNug/pihole-stuff/master/SNAFU.txt">https://raw.githubusercontent.com/RooneyMcNibNug/pihole-stuff/master/SNAFU.txt</a></li>
-  <li><a href="https://ssl.bblck.me/">paulgb's BarbBlock:</a><a href="https://ssl.bblck.me/blacklists/hosts-file.txt">https://ssl.bblck.me/blacklists/hosts-file.txt</a></li>
+  <li><a href="https://github.com/paulgb/BarbBlock">paulgb's BarbBlock:</a><a href="https://raw.githubusercontent.com/paulgb/BarbBlock/master/blacklists/hosts-file.txt">https://raw.githubusercontent.com/paulgb/BarbBlock/master/blacklists/hosts-file.txt</a></li>
   <li class="bdCross"><a href="https://hostsfile.mine.nu/">Andy Short:</a><a href="https://hostsfile.mine.nu/hosts0.txt">https://hostsfile.mine.nu/hosts0.txt</a></li>
   <li class="bdCross"><a href="http://www.sa-blacklist.stearns.org/sa-blacklist/">Bill Stearn:</a><a href="https://v.firebog.net/hosts/BillStearns.txt">https://v.firebog.net/hosts/BillStearns.txt</a>
   <li class="bdCross"><a href="https://hostsfile.org/hosts.html">Hostsfile.org:</a><a href="https://hostsfile.org/Downloads/hosts.txt">https://hostsfile.org/Downloads/hosts.txt</a></li>

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
   <li><a href="https://winhelp2002.mvps.org/">Winhelp2002 MVPS:</a><a href="https://winhelp2002.mvps.org/hosts.txt">https://winhelp2002.mvps.org/hosts.txt</a></li>
   <li><a href="https://github.com/neofelhz/neohosts">neoFelhz's neoHosts:</a><a href="https://hosts.nfz.moe/basic/hosts">https://hosts.nfz.moe/basic/hosts</a></li>
   <li><a href="https://github.com/RooneyMcNibNug/pihole-stuff/">RooneyMcNibNug's SNAFU list:</a><a href="https://raw.githubusercontent.com/RooneyMcNibNug/pihole-stuff/master/SNAFU.txt">https://raw.githubusercontent.com/RooneyMcNibNug/pihole-stuff/master/SNAFU.txt</a></li>
-  <li><a href="https://github.com/paulgb/BarbBlock">paulgb's BarbBlock:</a><a href="https://raw.githubusercontent.com/paulgb/BarbBlock/master/blacklists/hosts-file.txt">https://raw.githubusercontent.com/paulgb/BarbBlock/master/blacklists/hosts-file.txt</a></li>
+  <li><a href="https://github.com/paulgb/BarbBlock">paulgb's BarbBlock:</a><a href="https://paulgb.github.io/BarbBlock/blacklists/hosts-file.txt">https://paulgb.github.io/BarbBlock/blacklists/hosts-file.txt</a></li>
   <li class="bdCross"><a href="https://hostsfile.mine.nu/">Andy Short:</a><a href="https://hostsfile.mine.nu/hosts0.txt">https://hostsfile.mine.nu/hosts0.txt</a></li>
   <li class="bdCross"><a href="http://www.sa-blacklist.stearns.org/sa-blacklist/">Bill Stearn:</a><a href="https://v.firebog.net/hosts/BillStearns.txt">https://v.firebog.net/hosts/BillStearns.txt</a>
   <li class="bdCross"><a href="https://hostsfile.org/hosts.html">Hostsfile.org:</a><a href="https://hostsfile.org/Downloads/hosts.txt">https://hostsfile.org/Downloads/hosts.txt</a></li>


### PR DESCRIPTION
BarbBlock is now hosted on GitHub and the previous domain is up for sell. See https://github.com/DandelionSprout/adfilt/issues/113